### PR TITLE
License plate, phone number, and autocorrect hotfix

### DIFF
--- a/SpotHero_iOS_Partner_SDK.podspec
+++ b/SpotHero_iOS_Partner_SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name                  = 'SpotHero_iOS_Partner_SDK'
     s.ios.deployment_target = '9.0'
-    s.version               = '0.1.1'
+    s.version               = '0.1.2'
     s.summary               = 'An SDK for simple integration with SpotHero.'
     s.license               = 'LICENSE.md'
     s.description           = <<-DESC

--- a/SpotHero_iOS_Partner_SDK/Classes/CheckoutTableViewController.swift
+++ b/SpotHero_iOS_Partner_SDK/Classes/CheckoutTableViewController.swift
@@ -285,7 +285,7 @@ class CheckoutTableViewController: UIViewController {
         var license: String?
         
         if let
-            licenseCell = self.tableView.cellForRowAtIndexPath(NSIndexPath(forRow: PersonalInfoRow.Email.rawValue, inSection: CheckoutSection.PersonalInfo.rawValue)) as? PersonalInfoTableViewCell
+            licenseCell = self.tableView.cellForRowAtIndexPath(NSIndexPath(forRow: PersonalInfoRow.License.rawValue, inSection: CheckoutSection.PersonalInfo.rawValue)) as? PersonalInfoTableViewCell
             where facility.licensePlateRequired {
             license = licenseCell.textField.text
         }

--- a/SpotHero_iOS_Partner_SDK/Classes/CheckoutTableViewController.swift
+++ b/SpotHero_iOS_Partner_SDK/Classes/CheckoutTableViewController.swift
@@ -293,6 +293,7 @@ class CheckoutTableViewController: UIViewController {
         ReservationAPI.createReservation(facility,
                                          rate: rate,
                                          email: email,
+                                         phone: phoneNumber,
                                          stripeToken: token,
                                          license: license,
                                          completion: {

--- a/SpotHero_iOS_Partner_SDK/Classes/CheckoutTableViewController.swift
+++ b/SpotHero_iOS_Partner_SDK/Classes/CheckoutTableViewController.swift
@@ -355,6 +355,7 @@ class CheckoutTableViewController: UIViewController {
     
     private func configureCell(cell: PersonalInfoTableViewCell, row: PersonalInfoRow) {
         cell.titleLabel.text = row.title()
+        cell.textField.autocorrectionType = .No
         cell.textField.placeholder = row.placeholder()
         cell.textField.inputAccessoryView = self.toolbar
         cell.type = row

--- a/SpotHero_iOS_Partner_SDK/Classes/Network/ReservationAPI.swift
+++ b/SpotHero_iOS_Partner_SDK/Classes/Network/ReservationAPI.swift
@@ -16,6 +16,7 @@ struct ReservationAPI {
      - parameter facility:    Facility to create reservation
      - parameter rate:        Rate for the facility
      - parameter email:       User's email address
+     - parameter phone:       User's phone number. (optional) Pass in nil or omit this parameter if phone number is not required. Defaults to nil.
      - parameter stripeToken: Stripe token for user's credit card
      - parameter license:     User's license plate number. (optional) Pass in nil or omit this parameter if license is not required. If license plate is required and user does not pass it in, pass an empty string
      - parameter completion:  Completion that passes in either a reservation or error
@@ -23,6 +24,7 @@ struct ReservationAPI {
     static func createReservation(facility: Facility,
                                   rate: Rate,
                                   email: String,
+                                  phone: String? = nil,
                                   stripeToken: String,
                                   license: String? = nil,
                                   completion: (Reservation?, ErrorType?) -> (Void))  {
@@ -44,6 +46,10 @@ struct ReservationAPI {
             params["license_plate"] = license
         } else if license != nil {
             params["license_plate"] = "UNKNOWN"
+        }
+        
+        if let phone = phone where !phone.isEmpty {
+            params["phone_number"] = phone
         }
 
         let headers = APIHeaders.defaultHeaders()


### PR DESCRIPTION
This PR fixes 3 bugs in production: 
- The checkout VC was incorrectly grabbing the Email field and sending that to the server as the license plate.
- Phone numbers were not being sent to the server. 
- Autocorrect was enabled on personal info cells, which was screwing with email address input. 